### PR TITLE
F32

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,4 @@ authors = ["Ryan Walker <ryan@ryanwalker.us>"]
 docopt = "0.7.0"
 rustc-serialize = "0.3"
 random_choice = "0.3.2"
+fnv = "1.0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,10 +6,10 @@ use std::cmp::max;
 use self::random_choice::random_choice;
 
 pub struct GSDMM {
-    alpha: f64,
-    beta: f64,
+    alpha: f32,
+    beta: f32,
     K:usize,
-    V:f64,
+    V:f32,
     D:usize,
     maxit:isize,
     clusters: Vec<usize>,
@@ -21,7 +21,7 @@ pub struct GSDMM {
 }
 
 impl GSDMM {
-    pub fn new(alpha:f64, beta:f64, K: usize, maxit:isize, vocab:HashSet<String>, docs:Vec<Vec<String>>) -> GSDMM {
+    pub fn new(alpha:f32, beta:f32, K: usize, maxit:isize, vocab:HashSet<String>, docs:Vec<Vec<String>>) -> GSDMM {
         let D = docs.len();
 
         // compute utilized vocabulary size.
@@ -31,7 +31,7 @@ impl GSDMM {
                 utilized_vocab.insert(word.clone());
             }
         }
-        let V = utilized_vocab.len() as f64;
+        let V = utilized_vocab.len() as f32;
         println!("Fitting with alpha={}, beta={}, K={}, maxit={}, vocab size={}", alpha, beta, K, maxit, V as u32);
 
         let clusters = (0_usize..K).collect::<Vec<usize>>();
@@ -45,9 +45,9 @@ impl GSDMM {
         }
 
         // randomly initialize cluster assignment
-        let p = (0..K).map(|_| 1_f64 / (K as f64)).collect::<Vec<f64>>();
+        let p = (0..K).map(|_| 1_f32 / (K as f32)).collect::<Vec<f32>>();
 
-        let choices = random_choice().random_choice_f64(&clusters, &p, D) ;
+        let choices = random_choice().random_choice_f32(&clusters, &p, D) ;
         for i in 0..D {
             let z = choices[i].clone();
             let ref doc = docs[i];
@@ -109,7 +109,7 @@ impl GSDMM {
                 let p = self.score(&doc);
 
                 // choose the next cluster randomly according to the computed probability
-                let z_new: usize = random_choice().random_choice_f64(&self.clusters, &p, 1)[0].clone();
+                let z_new: usize = random_choice().random_choice_f32(&self.clusters, &p, 1)[0].clone();
 
                 // transfer document to the new cluster
                 if z_new != z_old {
@@ -141,7 +141,7 @@ impl GSDMM {
         }
     }
 
-    pub fn score(&self, doc:&Vec<String>) -> Vec<f64> {
+    pub fn score(&self, doc:&Vec<String>) -> Vec<f32> {
         /// Score an input document using the formula of Yin and Wang 2014 (equation 3)
         /// http://dbgroup.cs.tsinghua.edu.cn/wangjy/papers/KDD14-GSDMM.pdf
         ///
@@ -151,7 +151,7 @@ impl GSDMM {
         ///
         /// # Value
         ///
-        /// Vec<f64> - A length K probability vector where each component represents the probability
+        /// Vec<f32> - A length K probability vector where each component represents the probability
         /// of the doc belonging to a particular cluster.
         ///
 
@@ -161,28 +161,28 @@ impl GSDMM {
         // lN2 = log(D - 1 + K*alpha)
         // lN2 = log(product(n_z_w[w] + beta)) = sum(log(n_z_w[w] + beta))
         // lD2 = log(product(n_z[d] + V*beta + i -1)) = sum(log(n_z[d] + V*beta + i -1))
-        let mut p = (0..self.K).map(|_| 0_f64).collect::<Vec<f64>>();
-        let lD1 = ((self.D - 1) as f64 + (self.K as f64) * self.alpha).ln();
+        let mut p = (0..self.K).map(|_| 0_f32).collect::<Vec<f32>>();
+        let lD1 = ((self.D - 1) as f32 + (self.K as f32) * self.alpha).ln();
         let doc_size = doc.len() as u32;
         for label in 0_usize..self.K {
-            let lN1 = (self.cluster_counts[label] as f64 + self.alpha).ln();
-            let mut lN2 = 0_f64;
-            let mut lD2 = 0_f64;
+            let lN1 = (self.cluster_counts[label] as f32 + self.alpha).ln();
+            let mut lN2 = 0_f32;
+            let mut lD2 = 0_f32;
 
             let ref cluster: HashMap<String, u32> = self.cluster_word_distributions[label];
 
             for word in doc {
-                lN2 += (*cluster.get(word).unwrap_or(&0_u32) as f64 + self.beta).ln();
+                lN2 += (*cluster.get(word).unwrap_or(&0_u32) as f32 + self.beta).ln();
             }
             for j in 1_u32..(doc_size+1) {
-                lD2 += ((self.cluster_word_counts[label] + j) as f64 - 1_f64 + self.V * self.beta).ln();
+                lD2 += ((self.cluster_word_counts[label] + j) as f32 - 1_f32 + self.V * self.beta).ln();
             }
             p[label] = (lN1 - lD1 + lN2 - lD2).exp();
         }
 
         // normalize the probability
-        let pnorm: f64 = p.iter().sum();
-        if pnorm>0_f64 {
+        let pnorm: f32 = p.iter().sum();
+        if pnorm>0_f32 {
             for label in 0_usize..self.K {
                 p[label] = p[label] / pnorm;
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,10 +75,10 @@ fn main() {
         let mut scored = Vec::<(String,String,String)>::new();
 
         // zip with the input data so we get clustered, raw input documents in the output set
-        for (doc,txt) in (&model.docs).iter().zip(lines_from_file(&args.arg_datafile).iter()) {
+        for (doc,txt) in (&model.doc_vectors).iter().zip(lines_from_file(&args.arg_datafile).iter()) {
             let p = model.score( & doc);
             let mut row = p.iter().enumerate().collect::<Vec<_>>();
-            if row_has_nan(&row, &doc) {
+            if row_has_nan(&row, txt) {
                 scored.push(("-1".to_string(), "0".to_string(), txt.clone()));
             } else {
                 row.sort_by(|a, b| (a.1.partial_cmp(b.1)).unwrap());
@@ -100,7 +100,7 @@ fn main() {
         for k in 0..args.flag_k {
             let ref word_dist = model.cluster_word_distributions[k];
             let mut line = k.to_string() + " ";
-            let mut dist_counts:Vec<String> = word_dist.iter().map(|(a,b)| a.clone() + ":" + &b.clone().to_string() ).collect();
+            let mut dist_counts:Vec<String> = word_dist.iter().map(|(a,b)| model.index_word_map.get(a).unwrap().to_string() + ":" + &b.clone().to_string() ).collect();
             dist_counts.sort();
             line += &dist_counts.join(" ");
             f.write((line+"\n").as_bytes());
@@ -115,7 +115,7 @@ fn main() {
         buf.lines().map(|l| l.expect("Could not parse line!")).collect()
     }
 
-    fn row_has_nan(row:&Vec<(usize, &f32)>, doc:&Vec<String>) -> bool {
+    fn row_has_nan(row:&Vec<(usize, &f32)>, doc:&String) -> bool {
         for entry in row {
             if entry.1.is_nan() {
                 println!("Cluster: {:?} has NaN score for document {:?}", entry, doc);

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,8 +38,8 @@ struct Args {
     arg_vocabfile: String,
     arg_outprefix: String,
     flag_k: usize,
-    flag_alpha: f64,
-    flag_beta: f64,
+    flag_alpha: f32,
+    flag_beta: f32,
     flag_maxit: isize
 }
 
@@ -115,7 +115,7 @@ fn main() {
         buf.lines().map(|l| l.expect("Could not parse line!")).collect()
     }
 
-    fn row_has_nan(row:&Vec<(usize, &f64)>, doc:&Vec<String>) -> bool {
+    fn row_has_nan(row:&Vec<(usize, &f32)>, doc:&Vec<String>) -> bool {
         for entry in row {
             if entry.1.is_nan() {
                 println!("Cluster: {:?} has NaN score for document {:?}", entry, doc);


### PR DESCRIPTION
This branch:

- Replace f64 with f32 for a smaller memory footprint
- Maps each vocab word into a unique `usize` value, so that we can have both better hashmap performance and a more compact token representation in the doc cluster count maps.